### PR TITLE
reverted back from dtime_local to dtime_est/edt

### DIFF
--- a/app.R
+++ b/app.R
@@ -43,9 +43,9 @@
 
   
   #min_rainfall_date <- '1990-01-01'
-  max_rainfall_date <- as.Date(odbc::dbGetQuery(poolConn, paste0("select max(dtime_local) from data.tbl_gage_rain where dtime_local > '", refer_date, "'")) %>% pull)
+  max_rainfall_date <- as.Date(odbc::dbGetQuery(poolConn, paste0("select max(dtime_edt) from data.tbl_gage_rain where dtime_edt > '", refer_date, "'")) %>% pull)
   
-  max_baro_date <- as.Date(odbc::dbGetQuery(poolConn, paste0("SELECT max(dtime_local) FROM data.viw_barodata_neighbors where dtime_local > '", refer_date, "'")) %>% pull)
+  max_baro_date <- as.Date(odbc::dbGetQuery(poolConn, paste0("SELECT max(dtime_est) FROM data.viw_barodata_neighbors where dtime_est > '", refer_date, "'")) %>% pull)
 
   max_date = max(c(max_rainfall_date, max_baro_date))
   


### PR DESCRIPTION
The Postgres database caused issues and so we are going back to the previous dtime methods to avoid issues. Closes #4 